### PR TITLE
Add initial CLAUDE.md files for AI-assisted development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+<!-- Last reviewed: 2026-03 -->
+
+## Project
+
+Nextflow plugin that enables `syn://` URI access to Synapse (Sage Bionetworks) files in pipelines and samplesheets. Supports reading files/versions, writing via multipart upload, and auto-creating folder hierarchies. Published to the [Nextflow Plugin Registry](https://registry.nextflow.io).
+
+## Stack
+
+- **Language**: Groovy 3.0 on Java 21
+- **Build**: Gradle 9.3.0 (wrapper) with `io.nextflow.nextflow-plugin` v1.0.0-beta.14
+- **Nextflow**: 25.04.0+ required
+- **Test**: Spock 2.3-groovy-3.0, WireMock 3.3.1, JUnit Platform
+- **Plugin framework**: PF4J (via Nextflow's `BasePlugin`)
+
+## Commands
+
+```bash
+make assemble        # ./gradlew assemble
+make test            # ./gradlew test (unit tests only)
+make clean           # rm -rf .nextflow* work build && ./gradlew clean
+make install         # ./gradlew installPlugin (local Nextflow plugins dir)
+make release         # ./gradlew releasePlugin (publishes to registry)
+./gradlew build      # full build + test (used by CI)
+```
+
+## Data Models
+
+### syn:// URI formats
+- `syn://syn1234567` — latest version of entity
+- `syn://syn1234567.5` — specific version
+- `syn://syn1234567/filename.txt` — file in folder (write target)
+- `syn://syn1234567/path/to/file.txt` — nested path (auto-creates folders on write)
+
+Entity-only URIs are for reads. Folder/file URIs are for writes. `SynapsePath.isFolderFilePath()` distinguishes them.
+
+### Synapse REST API contracts
+- Entity metadata: `GET /repo/v1/entity/{synId}` — returns `concreteType`, `dataFileHandleId`, `name`, `etag`
+- File download: `GET /file/v1/file/{handleId}?redirect=false` — returns presigned URL (via redirect or JSON)
+- Folder children: `POST /repo/v1/entity/children` — returns `page[]` with `id`, `name`, `type`
+- Multipart upload: 4-step protocol (see `client/CLAUDE.md`)
+
+### META-INF registration (do not edit without updating source)
+- `extensions.idx` → `nextflow.synapse.SynapsePathFactory` (PF4J extension point)
+- `services/java.nio.file.spi.FileSystemProvider` → `nextflow.synapse.nio.SynapseFileSystemProvider` (Java NIO SPI)
+
+Keep these in sync with `build.gradle` `extensionPoints` and the actual class names. Mismatches silently break plugin loading.
+
+## Conventions
+
+- Annotate all classes with `@CompileStatic` — required for Nextflow plugin performance.
+- Use `@Slf4j` for logging (Groovy AST transform, not manual logger creation).
+- Map HTTP status codes to Java NIO exceptions: 401→`SecurityException`, 403→`AccessDeniedException`, 404→`NoSuchFileException`.
+- Error messages must be actionable: include what went wrong and how to fix it (e.g., "Set it via: `nextflow secrets set SYNAPSE_AUTH_TOKEN <your-token>`").
+- Use Groovy idioms: safe navigation (`?.`), Elvis (`?:`), `withStream`/`withCloseable` for resource management.
+
+## Architecture
+
+```
+Nextflow pipeline (syn:// URI in file(), publishDir, samplesheet)
+  → SynapsePathFactory (@Extension, registered in extensions.idx)
+    → SynapsePath + SynapseFileSystem
+      → SynapseFileSystemProvider (registered in META-INF/services)
+        ├─ Read: SynapseReadableByteChannel → presigned URL → HTTP stream
+        └─ Write: SynapseWritableByteChannel → temp file → SynapseUploader → multipart upload
+          → SynapseClient (REST API wrapper, Bearer auth)
+            → Synapse API + S3
+```
+
+Auth fallback chain: `synapse.authToken` config → `SYNAPSE_AUTH_TOKEN` Nextflow secret → `SYNAPSE_AUTH_TOKEN` env var.
+
+## Constraints
+
+- **Version is set by env var, not build.gradle** — `PLUGIN_VERSION` env var, defaults to `0.1.0`. CI sets this from the GitHub release tag. Do not hardcode versions.
+- **Release tags have no `v` prefix** — use `0.2.0`, not `v0.2.0`. The release workflow parses the tag directly as the version.
+- **NPR_API_KEY secret required for registry publishing** — stored in GitHub repo secrets. Without it, `make release` silently fails.
+- **Plugin structure matches nf-snowflake layout** — flattened (source at root, not nested under `plugins/`). This is required for the Nextflow plugin registry.
+- **SynapseFileSystemProvider is a singleton** — `instance()` returns a shared instance. The file system is created once and reused.
+- **delete() is a no-op** — Synapse doesn't support NIO deletion. Existing files get new versions on re-upload instead.
+- **newDirectoryStream() returns empty** — Synapse folders don't support NIO listing. This prevents `publishDir` cleanup from failing.
+
+## Testing
+
+- **Unit tests**: Spock specs in `src/test/`. Use `def "should [behavior]"()` naming. WireMock stubs Synapse REST API.
+- **Integration tests**: `validation/` directory — real Nextflow workflows against live Synapse. Require `SYNAPSE_AUTH_TOKEN` secret. Run via CI (`test.yml`) or locally.
+- **No linter/formatter configs exist** — code style is convention-based, not tool-enforced.
+
+## Related Systems
+
+- **Synapse REST API**: `https://repo-prod.prod.sagebase.org` (prod endpoint). Auth via Personal Access Tokens.
+- **nf-snowflake**: Reference template for Nextflow plugin structure. This repo's layout mirrors it.
+- **Nextflow Plugin Registry**: Where releases are published. Requires NPR_API_KEY.

--- a/src/main/groovy/nextflow/synapse/client/CLAUDE.md
+++ b/src/main/groovy/nextflow/synapse/client/CLAUDE.md
@@ -1,0 +1,37 @@
+<!-- Last reviewed: 2026-03 -->
+
+## Project
+
+REST API client layer for Synapse. Handles authentication, entity CRUD, file downloads via presigned URLs, and multipart uploads to S3.
+
+## Conventions
+
+- `SynapseClient` wraps all HTTP calls. Never make raw HTTP requests from outside this package.
+- Two `HttpClient` instances in `SynapseClient`: one follows redirects (normal API calls), one does not (`noRedirectClient` for presigned URL extraction from 307 responses).
+- `SynapseUploader` creates its own `HttpClient` for S3 uploads — these go directly to S3, not through Synapse API.
+- Auth is managed by `SynapseAuthManager` — always use `getAuthorizationHeader()`, never construct Bearer tokens manually.
+
+## Architecture
+
+### Multipart upload protocol (4 steps)
+1. `startMultipartUpload` — sends file metadata + MD5. Synapse may return `COMPLETED` immediately if the file already exists (deduplication by MD5).
+2. `getPresignedUploadUrls` — batch request for S3 presigned PUT URLs, one per part.
+3. Upload parts to S3 + `addUploadPart` — PUT bytes to S3, then confirm each part with Synapse (includes part MD5).
+4. `completeMultipartUpload` — returns `resultFileHandleId`.
+
+After upload: `createFileEntity` (new file) or `updateFileEntity` (new version of existing file, requires current `etag`).
+
+### Content-type detection
+`SynapseUploader.detectContentType()` maps file extensions to MIME types. Includes bioinformatics formats: BAM, VCF, FASTQ/FQ, FASTA/FA, BED. Unknown extensions default to `application/octet-stream`.
+
+### Part sizing
+- Minimum 5MB, maximum 5GB per part. Maximum 10,000 parts (S3 limit).
+- `calculatePartSize()` doubles from 5MB until `fileSize / partSize <= 10000`.
+
+## Constraints
+
+- **MD5 is streamed in 2MB chunks** — never buffer the entire file for hashing. This is deliberate to handle large genomics files.
+- **readFilePart uses RandomAccessFile** — seeks to offset and reads only one part. Known resource leak risk if exception occurs between open and close (GitHub issue #5).
+- **No retry logic** — all HTTP calls fail immediately on error. GitHub issue #7 tracks adding exponential backoff for transient failures (5xx, timeouts).
+- **HttpClient per-instance** — `SynapseUploader` creates a new `HttpClient`. GitHub issue #8 tracks sharing a single client.
+- **Folder creation is recursive** — `ensureFolderPath("results/qc")` creates `results/` then `qc/` inside it, checking for existing folders at each level to avoid duplicates.

--- a/src/main/groovy/nextflow/synapse/nio/CLAUDE.md
+++ b/src/main/groovy/nextflow/synapse/nio/CLAUDE.md
@@ -1,0 +1,45 @@
+<!-- Last reviewed: 2026-03 -->
+
+## Project
+
+Java NIO FileSystem SPI implementation for `syn://` URIs. This is the layer that makes Synapse files work transparently with Nextflow's `file()`, `publishDir`, and process I/O.
+
+## Conventions
+
+- `SynapseFileSystemProvider` is a **singleton** — `instance()` returns the shared instance. One `SynapseFileSystem` is created and reused.
+- `SynapsePath` is immutable after construction. `cachedFileName` uses double-checked locking for lazy initialization.
+- Entity-only paths (`syn://syn123`) are for reads. Folder/file paths (`syn://syn123/file.txt`) are for writes. Use `isFolderFilePath()` to distinguish.
+
+## Architecture
+
+### SynapsePath identity
+- `equals()` and `hashCode()` use `synId` + `version` + `fileSystem` identity only. **fileName is excluded** — this is intentional (GitHub issue #6 documents the decision). Two paths with the same synId/version but different fileNames are considered equal.
+- `toString()` calls `getActualFileName()`, which fetches the entity name from Synapse API on first call (lazy, cached). Falls back to synId on error — this silent catch is a known concern (GitHub issue #4).
+- `compareTo()` includes fileName for ordering, even though `equals()` does not.
+
+### URI parsing
+Two regex patterns in `SynapsePath`:
+- `SYNAPSE_ID_PATTERN`: `syn(\d+)(\.(\d+))?` — matches `syn1234567` or `syn1234567.5`
+- `SYNAPSE_FOLDER_FILE_PATTERN`: `syn(\d+)\/(.+)` — matches `syn1234567/filename.txt` or `syn1234567/path/to/file.txt`
+
+Folder/file pattern is tried first (more specific).
+
+### Read channel (SynapseReadableByteChannel)
+- Lazy-opens HTTP stream on first `read()` call, not on construction.
+- Forward-only: `position(newPos)` throws `UnsupportedOperationException` if `newPos != currentPosition`.
+- `write()`, `truncate()` throw `UnsupportedOperationException`.
+
+### Write channel (SynapseWritableByteChannel)
+- All writes go to a temp file (`synapse-upload-*.tmp`).
+- `close()` triggers the actual upload via `SynapseUploader`, then deletes the temp file.
+- Supports `position()` and `truncate()` (delegated to temp file channel).
+- `read()` throws `UnsupportedOperationException`.
+
+## Constraints
+
+- **newDirectoryStream() returns empty iterator** — Synapse folders don't support NIO listing. This is required so `publishDir` cleanup doesn't fail.
+- **delete() is a no-op** — Synapse doesn't support deletion via this plugin. Files get new versions on re-upload.
+- **move() throws UnsupportedOperationException** — no rename/move support.
+- **copy() handles cross-filesystem only** — local→Synapse (upload) and Synapse→local (download). Synapse→Synapse copy is not supported.
+- **checkAccess() for folder/file paths throws NoSuchFileException** — these are write-only destinations that don't exist as entities yet. This signals Nextflow to proceed with creation.
+- **createDirectory() is a validation-only no-op** — verifies the folder exists in Synapse but doesn't create it. Actual folder creation happens in `SynapseUploader.ensureFolderPath()`.

--- a/validation/CLAUDE.md
+++ b/validation/CLAUDE.md
@@ -1,0 +1,33 @@
+<!-- Last reviewed: 2026-03 -->
+
+## Project
+
+Integration test workflows that exercise the plugin against a live Synapse instance. These are not unit tests — they make real API calls and require authentication.
+
+## Commands
+
+```bash
+# Set auth token first
+nextflow secrets set SYNAPSE_AUTH_TOKEN <your-personal-access-token>
+
+# Read validation (direct access + samplesheet)
+nextflow run validation/main.nf --synapse_id syn1234567
+
+# Read + write (FizzBuzz round-trip with subfolder creation)
+nextflow run validation/main_fizzbuzz.nf --input syn://syn72514512 --outDir syn://syn72507092
+
+# Write-only validation
+nextflow run validation/main_write.nf --input <local-file> --outDir syn://synXXXXX
+```
+
+## Conventions
+
+- All workflows use `nextflow.enable.dsl = 2`.
+- `nextflow.config` declares the plugin (`nf-synapse@0.1.0`) and reads auth from secrets. Update the version here when testing a new release.
+- CI runs these after `make install` — the installed plugin version must match what `nextflow.config` declares.
+
+## Constraints
+
+- **Requires SYNAPSE_AUTH_TOKEN** — a Synapse Personal Access Token. Without it, all workflows fail at authentication.
+- **Requires real Synapse entities** — the syn IDs in CI and examples must point to existing entities the token has access to. Do not use placeholder IDs.
+- **Write tests create real data** — `main_fizzbuzz.nf` and `main_write.nf` upload files to Synapse. Use a test folder, not production data.


### PR DESCRIPTION
## Summary
- Add root `CLAUDE.md` (91 lines) covering project overview, stack, commands, syn:// URI formats, Synapse REST API contracts, META-INF registration rules, coding conventions, architecture diagram, and constraints
- Add `client/CLAUDE.md` (37 lines) documenting the 4-step multipart upload protocol, content-type detection, part sizing, and known issues (#5, #7, #8)
- Add `nio/CLAUDE.md` (45 lines) documenting SynapsePath identity/equals semantics, URI parsing regexes, read/write channel behavior, and NIO no-ops (delete, listing, move)
- Add `validation/CLAUDE.md` (33 lines) documenting run commands, auth requirements, and real-entity dependencies

## Test plan
- [ ] Verify each file is under 150 lines
- [ ] Verify no duplication of README content
- [ ] Verify all commands match Makefile/CI configs
- [ ] Verify META-INF registration descriptions match actual files

🤖 Generated with [Claude Code](https://claude.com/claude-code)